### PR TITLE
Fix: Lock jenkins image version for tutorial_01

### DIFF
--- a/tutorial_01/makefile
+++ b/tutorial_01/makefile
@@ -1,7 +1,9 @@
+JENKINS_IMAGE = jenkins:1.609.1
+
 build:
-	@docker pull jenkins
+	@docker pull $(JENKINS_IMAGE)
 run:
-	@docker run -p 8080:8080 --name=jenkins-master -d --env JAVA_OPTS="-Xmx8192m" --env JENKINS_OPTS="--handlerCountStartup=100 --handlerCountMax=300" jenkins
+	@docker run -p 8080:8080 --name=jenkins-master -d --env JAVA_OPTS="-Xmx8192m" --env JENKINS_OPTS="--handlerCountStartup=100 --handlerCountMax=300" $(JENKINS_IMAGE)
 start:
 	@docker start jenkins-master
 stop:


### PR DESCRIPTION
## Context

It was impossible to run latest jenkins image with environment variables you specified

```
Running from: /usr/share/jenkins/jenkins.war
webroot: EnvVars.masterEnvVars.get("JENKINS_HOME")
Exception in thread "main" java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at Main._main(Main.java:246)
    at Main.main(Main.java:91)
Caused by: java.lang.IllegalArgumentException: Unrecognized option: --handlerCountStartup=100
    at winstone.cmdline.CmdLineParser.parse(CmdLineParser.java:53)
    at winstone.Launcher.getArgsFromCommandLine(Launcher.java:359)
    at winstone.Launcher.main(Launcher.java:332)
    ... 6 more
```
## Scope of changes
- Lock version of jenkins image to one that supports your environment variables
