### PR TITLE
Adding versions to plugins

### DIFF
--- a/jenkins2/jenkins-master/plugins.txt
+++ b/jenkins2/jenkins-master/plugins.txt
@@ -1,64 +1,64 @@
-ace-editor
-antisamy-markup-formatter
-authentication-tokens
-bouncycastle-api
-branch-api
-build-timeout
-cloudbees-folder
-credentials
-credentials-binding
-display-url-api
-docker-commons
-durable-task
-email-ext
-external-monitor-job
-git
-git-client
-git-server
-github
-github-api
-github-branch-source
-github-organization-folder
-groovy
-handlebars
-icon-shim
-jclouds-jenkins
-jquery-detached
-junit
-ldap
-mailer
-mapdb-api
-matrix-auth
-matrix-project
-momentjs
-pam-auth
-pipeline-build-step
-pipeline-graph-analysis
-pipeline-input-step
-pipeline-rest-api
-pipeline-stage-step
-pipeline-stage-view
-plain-credentials
-scm-api
-script-security
-scriptler
-ssh-credentials
-ssh-slaves
-structs
-subversion
-timestamper
-token-macro
-windows-slaves
-workflow-aggregator
-workflow-api
-workflow-basic-steps
-workflow-cps
-workflow-cps-global-lib
-workflow-durable-task-step
-workflow-job
-workflow-multibranch
-workflow-scm-step
-workflow-step-api
-workflow-support
-ws-cleanup
-yet-another-docker-plugin
+ace-editor 1.1
+antisamy-markup-formatter 1.5
+authentication-tokens 1.3
+bouncycastle-api 2.16.0
+branch-api 1.10.2
+build-timeout 1.17.1
+cloudbees-folder 5.12
+credentials 2.1.4
+credentials-binding 1.9
+display-url-api 0.3
+docker-commons 1.4.1
+durable-task 1.12
+email-ext 2.47
+external-monitor-job 1.6
+git 3.0.0
+git-client 2.0.0
+git-server 1.7
+github 1.21.1
+github-api 1.77
+github-branch-source 1.9
+github-organization-folder 1.5
+groovy 1.29
+handlebars 1.1.1
+icon-shim 2.0.3
+jclouds-jenkins 2.8.1-1
+jquery-detached 1.2.1
+junit 1.18
+ldap 1.12
+mailer 1.18
+mapdb-api 1.0.9.0
+matrix-auth 1.4
+matrix-project 1.7.1
+momentjs 1.1.1
+pam-auth 1.3
+pipeline-build-step 2.2
+pipeline-graph-analysis 1.1
+pipeline-input-step 2.1
+pipeline-rest-api 2.0
+pipeline-stage-step 2.2
+pipeline-stage-view 2.0
+plain-credentials 1.2
+scm-api 1.3
+script-security 1.22
+scriptler 2.9
+ssh-credentials 1.12
+ssh-slaves 1.11
+structs 1.5
+subversion 2.6
+timestamper 1.8.5
+token-macro 1.12.1
+windows-slaves 1.2
+workflow-aggregator 2.3
+workflow-api 2.3
+workflow-basic-steps 2.1
+workflow-cps 2.17
+workflow-cps-global-lib 2.3
+workflow-durable-task-step 2.4
+workflow-job 2.6
+workflow-multibranch 2.8
+workflow-scm-step 2.2
+workflow-step-api 2.3
+workflow-support 2.4
+ws-cleanup 0.30
+yet-another-docker-plugin 0.1.0-rc24


### PR DESCRIPTION
On second thought, any update to any plugin which adds new dependencies will break the demo. Require versions to add stability.
